### PR TITLE
Update expired keys

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -200,7 +200,7 @@ def all_keys(module, keyring, short_format):
     results = []
     lines = to_native(out).split('\n')
     for line in lines:
-        if line.startswith("pub") or line.startswith("sub"):
+        if (line.startswith("pub") or line.startswith("sub")) and not "expired" in line:
             tokens = line.split()
             code = tokens[1]
             (len_type, real_code) = code.split("/")


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - apt_key

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### SUMMARY
If a key has expired it will not be added/updated by this module as it's still in the list of public keys, so check for the "expired" keyword in apt-key's output before adding the key to the list of results.

Example output of "apt-key adv --list-public-keys --keyid-format=long" with expired key:

```
pub   1024D/5072E1F5 2003-02-03 [expired: 2017-02-16]
uid                  MySQL Release Engineering <mysql-build@oss.oracle.com>
```

An expired key can be updated with the same command that's used for adding a key.